### PR TITLE
Add SQLAlchemy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # MCPFinanceiro
 Servidor de MCP de administração de lançamentos financeiros contabeis
+
+## Banco de Dados
+O arquivo `database.py` usa SQLAlchemy para gerenciar as conexões. Por padrao o
+projeto cria um banco SQLite local (`mcp.db`). Para utilizar PostgreSQL ou outro
+banco defina a variavel de ambiente `DB_URL` com a string de conexao, por
+exemplo:
+
+```bash
+export DB_URL=postgresql://usuario:senha@localhost:5432/minha_base
+```
+
+### Migracoes com Alembic
+Para criar e atualizar estruturas de banco utilize o [Alembic](https://alembic.sqlalchemy.org/):
+
+```bash
+pip install sqlalchemy alembic
+alembic init alembic
+# configure o arquivo alembic.ini e gere as revisoes
+alembic revision --autogenerate -m "mensagem"
+alembic upgrade head
+```
+

--- a/database.py
+++ b/database.py
@@ -1,0 +1,24 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+# Database URL fetched from environment or defaults to local SQLite file
+DB_URL = os.getenv("DB_URL", "sqlite:///./mcp.db")
+
+# Additional connection arguments are required for SQLite
+connect_args = {"check_same_thread": False} if DB_URL.startswith("sqlite") else {}
+
+engine = create_engine(DB_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# Base class for ORM models
+Base = declarative_base()
+
+
+def get_session():
+    """Provide a transactional scope around a series of operations."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- add `database.py` with basic SQLAlchemy engine and session handling
- document DB URL configuration and Alembic migration steps in README

## Testing
- `python3 -m py_compile database.py`

------
https://chatgpt.com/codex/tasks/task_e_685361c870e08320a966e979f757eade