### PR TITLE
Disable automatic table drops in Alembic

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ alembic upgrade head
 Esses comandos geram arquivos de revisão na pasta `alembic` e aplicam o
 upgrade para a versão mais recente do schema.
 
+O arquivo `alembic/env.py` já inclui uma função `should_include_object` que
+inibe a geração automática de `DropTable`. Assim, tabelas existentes não são
+removidas quando você executa `alembic revision --autogenerate`. Caso precise
+excluir uma tabela, edite manualmente a revisão gerada.
+
 ### Atualizando o banco de dados
 
 Quando novas colunas ou tabelas são adicionadas aos modelos, é necessário gerar

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -12,6 +12,16 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from database import Base
 target_metadata = Base.metadata
 
+
+def should_include_object(object, name, type_, reflected, compare_to):
+    """Return True if the object should be included in autogeneration."""
+    # Skip dropping tables that exist in the database but are missing from the
+    # SQLAlchemy models. This prevents ``DropTable`` operations from being
+    # generated automatically.
+    if type_ == "table" and compare_to is None:
+        return False
+    return True
+
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
@@ -49,6 +59,7 @@ def run_migrations_offline() -> None:
     context.configure(
         url=url,
         target_metadata=target_metadata,
+        include_object=should_include_object,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
     )
@@ -72,7 +83,9 @@ def run_migrations_online() -> None:
 
     with connectable.connect() as connection:
         context.configure(
-            connection=connection, target_metadata=target_metadata
+            connection=connection,
+            target_metadata=target_metadata,
+            include_object=should_include_object,
         )
 
         with context.begin_transaction():


### PR DESCRIPTION
## Summary
- adjust `alembic/env.py` to skip generating `DropTable`
- document new behaviour in the Alembic section of the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685425d0c1a88320a2e9cf2da94ab78c