### PR TITLE
Add conftest for pytest imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path so imports in tests work
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- ensure tests import project modules without using `PYTHONPATH`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68542c6c05ec8320b7b41f03431a1db1